### PR TITLE
ページネーションコンポーネントのデモサイト公開及びリファクタリング（再）

### DIFF
--- a/frontend/the-pagination/README.md
+++ b/frontend/the-pagination/README.md
@@ -1,6 +1,9 @@
 ## thePagination
 `Next.js`のシンプルで汎用的なページネーションコンポーネント
 
+- [デモサイト](https://k2webservice.xsrv.jp/r0105/the-pagination)<br>
+※`next.config.ts`でデプロイ設定
+
 - `src\providers\PagerContextFragment.tsx`<br>
 「ページャ数」と「ページに表示するコンテンツデータ数（`posts_per_page`）」のグローバルステートを管理しているファイル
 - `src\app\layout.tsx`<br>

--- a/frontend/the-pagination/next.config.ts
+++ b/frontend/the-pagination/next.config.ts
@@ -1,7 +1,13 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  // output: 'export',
+  // trailingSlash: true,
+  // assetPrefix: '/r0105/the-pagination',
+  // basePath: '/r0105/the-pagination',
+  // images: {
+  //   unoptimized: true,
+  // },
 };
 
 export default nextConfig;

--- a/frontend/the-pagination/src/utils/PagerBtns.tsx
+++ b/frontend/the-pagination/src/utils/PagerBtns.tsx
@@ -11,21 +11,19 @@ function Pagers({ maxPage }: { maxPage: number }) {
     const { pagerNum } = useContext(PagerContext);
 
     const createPagers: () => number[] = () => {
-        const srcAry: number[] = [];
         let srcNum: number = maxPage;
 
         // 各ページャー項目を生成
         // srcNum（引算用途の上限数値）が 0 を切るまでオフセット数を倍数していくループ処理
         let Accumuration = 0;
         while (srcNum >= 0) {
-            srcAry.push(OFFSET_NUMBER * Accumuration);
             Accumuration++;
             srcNum = srcNum - OFFSET_NUMBER;
         }
 
         //（コンテンツデータに応じた）ページャー（項目）数の要素を持つ配列を用意して（初期値として）0をセット
         // map 処理で各初期値をインデックスインクリメント（順次繰り上げ）した数に置換（加工）する
-        return Array(srcAry.length).fill(0).map((_, i) => i + 1);
+        return Array(Accumuration).fill(0).map((_, i) => i + 1);
     }
     const thePagers: number[] = createPagers();
 

--- a/frontend/the-pagination/src/utils/PagerBtns.tsx
+++ b/frontend/the-pagination/src/utils/PagerBtns.tsx
@@ -14,7 +14,8 @@ function Pagers({ maxPage }: { maxPage: number }) {
         const srcAry: number[] = [];
         let srcNum: number = maxPage;
 
-        /* 各ページャー項目の data-pager の値を生成（引算用途の上限数値：srcNum が 0 を切るまでオフセット数を倍数していくループ処理）*/
+        // 各ページャー項目を生成
+        // srcNum（引算用途の上限数値）が 0 を切るまでオフセット数を倍数していくループ処理
         let Accumuration = 0;
         while (srcNum >= 0) {
             srcAry.push(OFFSET_NUMBER * Accumuration);
@@ -22,11 +23,10 @@ function Pagers({ maxPage }: { maxPage: number }) {
             srcNum = srcNum - OFFSET_NUMBER;
         }
 
-        //（コンテンツデータに応じた）ページャー数の要素を持つ配列を用意して（初期値として）0をセット
+        //（コンテンツデータに応じた）ページャー（項目）数の要素を持つ配列を用意して（初期値として）0をセット
         // map 処理で各初期値をインデックスインクリメント（順次繰り上げ）した数に置換（加工）する
         return Array(srcAry.length).fill(0).map((_, i) => i + 1);
     }
-
     const thePagers: number[] = createPagers();
 
     const scrollTop: () => void = () => {


### PR DESCRIPTION
- ページネーションコンポーネントのデモサイト公開
  - `frontend/the-pagination/README.md`
  - `frontend/the-pagination/next.config.ts`<br>デプロイ設定に関する記述
- リファクタリング
  - `frontend/the-pagination/src/utils/PagerBtns.tsx`<br>再修正ver（配列`srcAry`を用いた冗長な記述を削除）